### PR TITLE
Update tooltipSelector to match newer convention

### DIFF
--- a/chartist-plugin-tooltip.js
+++ b/chartist-plugin-tooltip.js
@@ -39,7 +39,7 @@
                 if (chart instanceof Chartist.Bar) {
                     tooltipSelector = '.ct-bar';
                 } else if (chart instanceof Chartist.Pie) {
-                    tooltipSelector = '.ct-slice';
+                    tooltipSelector = '[class^=ct-slice]';
                 }
 
                 var $chart = $(chart.container),


### PR DESCRIPTION
In current version of chartist Pie charts has either ct-slice-pie or ct-slice-donut
